### PR TITLE
st.2110: add workaround to avoid errors from ST.2110-31 files

### DIFF
--- a/checkST2110.js
+++ b/checkST2110.js
@@ -33,7 +33,8 @@ const fmtpParams = /([^\s=;]+(?:=[^\s;]+)?);/g;
 const integerPattern = /^[1-9]\d*$/;
 const frameRatePattern = /^([1-9]\d*)(?:\/([1-9]\d*))?$/;
 const parPattern = /^([1-9]\d*):([1-9]\d*)$/;
-const rtpmapSound = /a=rtpmap:(\d+)\s+(L16|L24)\/([1-9]\d*)\/([1-9]\d*)/;
+// TODO: Move AM824 into a separate set of tests specific to ST.2110-31
+const rtpmapSound = /a=rtpmap:(\d+)\s+(L16|L24|AM824)\/([1-9]\d*)\/([1-9]\d*)/;
 const ptimePattern = /^a=ptime:(\d+(?:\.\d+)?)$/;
 const maxptimePattern = /^a=maxptime:(\d+(?:\.\d+)?)$/;
 const audioPattern = /audio\s+(\d+)(\/\d+)?\s+(RTP\/S?AVP)\s+(\d+)/;


### PR DESCRIPTION
This is intended to be a temporary workaround for https://github.com/Streampunk/sdpoker/issues/17 in order to avoid mis-reporting of errors. When I have more time I'd hope to add proper support for ST.2110-31 which requires some additional tests.