### PR TITLE
Support empty <format specific parameters> in a=fmtp: line

### DIFF
--- a/checkST2110.js
+++ b/checkST2110.js
@@ -30,7 +30,7 @@ const videoPattern = /video\s+(\d+)(\/\d+)?\s+(RTP\/S?AVP)\s+(\d+)/;
 const rtpmapPattern = /a=rtpmap:(\d+)\s(\S+)\/(\d+)\s*/;
 const fmtpElement = '([^\\s=;]+)(?:=([^\\s;]+))?';
 const fmtpSeparator = '(?:;\\s*)';
-const fmtpPattern = new RegExp('a=fmtp:(\\d+)\\s+' + fmtpElement + '(' + fmtpSeparator + fmtpElement + ')*' + fmtpSeparator + '?$');
+const fmtpPattern = new RegExp('a=fmtp:(\\d+)\\s*(\\s' + fmtpElement + '(' + fmtpSeparator + fmtpElement + ')*' + fmtpSeparator + '?)?$');
 const fmtpParams = new RegExp(fmtpElement + fmtpSeparator + '?', 'g');
 const integerPattern = /^[1-9]\d*$/;
 const frameRatePattern = /^([1-9]\d*)(?:\/([1-9]\d*))?$/;

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -493,7 +493,6 @@ const extractMTParams = (sdp, params = {}) => {
         continue;
       }
       let fmtParams = lines[x].split(/a=fmtp:\d+\s+/)[1];
-      // let paramsMatch = fmtParams.matchAll(fmtpParams);
       let paramsMatch = [];
       let paramMatch;
       while ((paramMatch = fmtpParams.exec(fmtParams)) !== null)

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -492,11 +492,11 @@ const extractMTParams = (sdp, params = {}) => {
       if (!fmtpPattern.test(lines[x])) {
         continue;
       }
-      let params = lines[x].split(/a=fmtp:\d+\s+/)[1];
-      // let paramsMatch = params.matchAll(fmtpParams);
+      let fmtParams = lines[x].split(/a=fmtp:\d+\s+/)[1];
+      // let paramsMatch = fmtParams.matchAll(fmtpParams);
       let paramsMatch = [];
       let paramMatch;
-      while ((paramMatch = fmtpParams.exec(params)) !== null)
+      while ((paramMatch = fmtpParams.exec(fmtParams)) !== null)
           paramsMatch.push(paramMatch);
       let splitParams = paramsMatch.map(p => [p[1], p[2] || '']);
       if (params.checkDups) {


### PR DESCRIPTION
Proposed fix for #14.

Note that there's still more to do to bring ST 2110-40 testing up to same level as ST 2110-20, see #4.
And #11 is required ASAP as well, now the ST 2110-xx:2022 revisions are imminent.