### PR TITLE
ST 2110-xx:2022 updates

### DIFF
--- a/checkRFC4566.js
+++ b/checkRFC4566.js
@@ -138,7 +138,7 @@ const test_50_5 = lines => {
     let movingOn = followedBy[state][types[x - 1]];
     nextState = movingOn ? movingOn : nextState;
     if (Object.keys(nextState).indexOf(types[x]) < 0) {
-      errors.push(new Error(`Line ${x + 1}: SDP type '${types[x - 1]}' cannot be followed by type '${types[x]}', as per the fixed order or RFC 4566 Section 5.`));
+      errors.push(new Error(`Line ${x + 1}: SDP type '${types[x - 1]}' cannot be followed by type '${types[x]}', as per the fixed order of RFC 4566 Section 5.`));
     } else {
       state = nextState[types[x]];
     }

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -758,18 +758,31 @@ const test_20_72_4 = (sdp, params) => {
   return errors;
 };
 
-// ST 2110-20 Section 7.2 Test 5 - Check SSN is the required fixed value
+const ssnPermitted = ['ST2110-20:2017', 'ST2110-20:2022'];
+
+// ST 2110-20:2017 Section 7.2
+// ST 2110-20:2022 Section 7.2 Test 5 - Check SSN is the required fixed value
 const test_20_72_5 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined') {
-      if (stream.SSN !== 'ST2110-20:2017') {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value 'ST2110-20:2017', as per ST 2110-20 Section 7.2.`));
+      if (ssnPermitted.indexOf(stream.SSN) < 0) {
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value 'ST2110-20:2017' or 'ST2110-20:2022', as per ST 2110-20:2017 and ST 2110-20:2022 Section 7.2.`));
+      } else {
+        let detect2022tcs = typeof stream.TCS !== 'undefined' && stream.TCS === 'ST2115LOGS3';
+        let detect2022colorimetry = typeof stream.colorimetry !== 'undefined' && stream.colorimetry === 'ALPHA';
+
+        if ((detect2022tcs || detect2022colorimetry) && stream.SSN !== 'ST2110-20:2022') {
+          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value 'ST2110-20:2022', as per ST 2110-20:2022 Section 7.2.`));
+        }
+        if (!(detect2022tcs || detect2022colorimetry) && stream.SSN === 'ST2110-20:2022') {
+          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value 'ST2110-20:2017', as per ST 2110-20:2022 Section 7.2.`));
+        }
       }
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-20 Section 7.2 Test 5 - SSN is the required fixed value \'ST 2110-20:2017\'');
+    console.log('Test Passed: ST 2110-20:2017 and ST 2110-20:2022 Section 7.2 Test 5 - SSN is the required fixed value \'ST 2110-20:2017\'');
   }
   return errors;
 };
@@ -916,17 +929,20 @@ const test_20_74_2 = (sdp, params) => {
   return errors;
 };
 
-const colorPermitted = [
+const colorPermitted2017 = [
   'BT601', 'BT709', 'BT2020', 'BT2100', 'ST2065-1',
   'ST2065-3', 'UNSPECIFIED', 'XYZ'];
 
-// ST 2110-20 Section 7.5 Test 1 - Colorimetry is a permitted value.
+const colorPermitted2022 = ['ALPHA'];
+
+// ST 2110-20:2017 Section 7.5
+// ST 2110-20:2022 Section 7.4 Test 1 - Colorimetry is a permitted value.
 const test_20_75_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.colorimetry !== 'undefined') {
-      if (colorPermitted.indexOf(stream.colorimetry) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'colorimetry' is not a permitted value, as per ST 2110-20 Section 7.5.`));
+      if (colorPermitted2017.indexOf(stream.colorimetry) < 0 && colorPermitted2022.indexOf(stream.colorimetry) < 0) {
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'colorimetry' is not a permitted value, as per ST 2110-20:2017 Section 7.5 and ST 2110-20:2022 Section 7.4.`));
       }
     }
   }
@@ -958,23 +974,26 @@ const test_20_75_2 = (sdp, params) => {
   return errors;
 };
 
-const tcsPermitted = [
+const tcsPermitted2017 = [
   'SDR', 'PQ', 'HLG', 'LINEAR', 'BT2100LINPQ', 'BT2100LINHLG', 'ST2065-1',
   'ST428-1', 'DENSITY', 'UNSPECIFIED'
 ];
 
-// ST 2110-20 Section 7.6 Test 1 - TCS is a permitted value
+const tcsPermitted2022 = ['ST2115LOGS3'];
+
+// ST 2110-20:2017 Section 7.6 
+// ST 2110-20:2022 Section 7.5 Test 1 - TCS is a permitted value
 const test_20_76_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.TCS !== 'undefined') {
-      if (tcsPermitted.indexOf(stream.TCS) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TCS' (Transfer Characteristic System) is not a permitted value, as per ST 2110-20 Section 7.6.`));
+      if (tcsPermitted2017.indexOf(stream.TCS) < 0 && tcsPermitted2022.indexOf(stream.TCS) < 0) {
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TCS' (Transfer Characteristic System) is not a permitted value, as per ST 2110-20:2017 Section 7.6 and ST 2110-20:2012 Section 7.5.`));
       }
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-20 Section 7.6 Test 1 - TCS is a permitted value');
+    console.log('Test Passed: ST 2110-20:2017 Section 7.6, ST 2110-20:2022 Section 7.5 Test 1 - TCS is a permitted value');
   }
   return errors;
 };

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1275,6 +1275,8 @@ const test_21_81_2 = (sdp, params) => {
   return errors;
 };
 
+/* When troff (Transmit offset) is present it must be expressed as a positive integer. This function checks for conformance with ST2110-21 Section  8.2.
+*/
 const checkTroff = (stream = {}) => {
   let errors = [];
   let troff = +stream.TROFF;

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -458,9 +458,9 @@ const test_10_62_1 = (sdp, params) => {
   return errors;
 };
 
-const tsmodePermitted2022 = ['NEW', 'SAMP', 'PRES'];
+const tsmodePermitted2022 = ['SAMP', 'NEW', 'PRES'];
 
-// ST 2110-10:2022 Section 8.7 Test 1 - RTP Timestamp Mode and Delay
+// ST 2110-10:2022 Section 8.7 Test 1 - RTP Timestamp Mode and Delay, TSMODE and TSDELAY parameters are an acceptable value.
 const test_10_87_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, { checkDups: true });
   for (let stream of mtParams) {
@@ -477,7 +477,7 @@ const test_10_87_1 = (sdp, params) => {
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-10:2022 Section 8.7 Test 1 - RTP Timestamp Mode and Delay');
+    console.log('Test Passed: ST 2110-10:2022 Section 8.7 Test 1 - RTP Timestamp Mode and Delay, TSMODE and TSDELAY parameters are an acceptable value.');
   }
   return errors;
 };

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -101,7 +101,7 @@ a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
 a=mediaclk:direct=0
 a=mid:SECONDARY`;
 
-// NOTE: all ST 2110 references are for the originally published specifications unless otherwise indicated
+// NOTE: all ST 2110 references are for the originally published specifications unless a later revision is indicated
 
 // ST 2110-10 Section 7.4 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero
 // [Also ST 2110-10:2022 Section 8.3]

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -101,8 +101,8 @@ a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
 a=mediaclk:direct=0 
 a=mid:SECONDARY`;
 
-// ST 2110-10:2017 Section 7.4
-// ST 2110-10:2022 Section 8.3 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero
+// ST 2110-10:2017 Section 7.4 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero
+// [Also ST 2110-10:2022 Section 8.3]
 const test_10_74_1 = (sdp, params) => {
   let errors = [];
   let streams = sdp.split(/[\r\n]m=/).slice(1);
@@ -119,13 +119,13 @@ const test_10_74_1 = (sdp, params) => {
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-10 Section 7.4 and ST 2110-10:2022 Section 8.3 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero');
+    console.log('Test Passed: ST 2110-10 Section 7.4 [also ST 2110-10:2022 Section 8.3] Test 1 - Where mediaclk:direct is used with PTP, offset value is zero');
   }
   return errors;
 };
 
-// ST 2110-10:2017 Section 8.1
-// ST 2110-10:2022 Section 8.3 Test 1 - Shell have media - level mediaclk per stream
+// ST 2110-10 Section 8.1 Test 1 - Shall have media-level mediaclk per stream
+// [Also ST 2110-10:2022 Section 8.3]
 const test_10_81_1 = (sdp, params) => {
   let errors = [];
   let streams = sdp.split(/[\r\n]m=/).slice(1);
@@ -135,13 +135,13 @@ const test_10_81_1 = (sdp, params) => {
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-10:2017 and ST 2110-10:2022 Section 8.3 Section 8.1 Test 1 - Shall have media-level mediaclk per stream');
+    console.log('Test Passed: ST 2110-10:2017 Section 8.1 [also ST 2110-10:2022 Section 8.3] Test 1 - Shall have media-level mediaclk per stream');
   }
   return errors;
 };
 
 // ST 2110-10:2017 Section 8.1 Test 2 - Should have mediaclk using direct reference
-// ST 2110-10:2022 Section 8.3 Test 2 - Shall have mediaclk using direct or sender reference
+// [Also ST 2110-10:2022 Section 8.3 - Shall have mediaclk using direct or sender reference]
 const test_10_81_2 = (sdp, params) => {
   if (!params.should) {
     if (params.verbose) {
@@ -788,8 +788,8 @@ const test_20_72_4 = (sdp, params) => {
 
 const ssnPermitted20 = ['ST2110-20:2017', 'ST2110-20:2022'];
 
-// ST 2110-20:2017 Section 7.2
-// ST 2110-20:2022 Section 7.2 Test 5 - Check SSN is the required fixed value
+// ST 2110-20:2017 Section 7.2 Test 5 - Check SSN is the required fixed value
+// [also ST 2110-20:2022 Section 7.2]
 const test_20_72_5 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
@@ -1360,7 +1360,7 @@ const test_22_72_2 = (sdp, params) => {
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-22:2022 Section 7.2 Test 5 - SSN is the required fixed value \'ST 2110-20:2017\'');
+    console.log('Test Passed: ST 2110-22:2022 Section 7.2 Test 2 - SSN is the required fixed value.');
   }
   return errors;
 };

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1716,8 +1716,8 @@ const allSections = (sdp, params) => {
         sections.push(no_copy_20);
       }
     } else if (mtParams[0]._encodingName == 'smpte291') {
-      sections = [section_10_62, section_10_74, section_10_81, section_10_82,
-        section_10_83, section_10_2022_87, section_40_2023_7];
+      sections = [section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87,
+        section_40_2023_7];
     } else {
       sections = [
         section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87];

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1498,27 +1498,30 @@ const test_22_74_1 = (sdp, params) => {
 
 const ssnPermitted40 = ['ST2110-40:2018', 'ST2110-40:2021'];
 
-// ST 2110-40:2023 Section 7 Test 1 - Check SSN is the required fixed value
+// ST 2110-40:2023 Section 7 Test 1 - Check SSN if present is the required fixed value
+/* Tests for conformance with ST 2110-40:2023:
+Senders implementing this standard shall signal a Format Specific Parameter SSN with the value ST2110-40:2018 unless they are signaling Format Specific Parameter TM, in which case they shall signal the value ST2110-40:2021.
+*/
 const test_40_2023_7_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined') {
       if (ssnPermitted40.indexOf(stream.SSN) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-40:2023 Section 7.`));
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to a required value as per ST 2110-40:2023 Section 7.`));
       } else {
         let detect2023tm = typeof stream.TM !== 'undefined';
 
         if (detect2023tm && stream.SSN === 'ST2110-40:2018') {
-          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-40:2023 Section 7.`));
+          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' should be set to ST2110-40:2021 when TM is present as per ST 2110-40:2023 Section 7.`));
         }
         if (!detect2023tm && stream.SSN !== 'ST2110-40:2018') {
-          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-40:2023 Section 7.`));
+          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' must be  set ST2110-40:2018 when TM is not present as per ST 2110-40:2023 Section 7.`));
         }
       }
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-40:2023 Section 7 Test 1 - SSN is the required fixed value.');
+    console.log('Test Passed: ST 2110-40:2023 Section 7 Test 1 - SSN if present is the required fixed value.');
   }
   return errors;
 };
@@ -1531,7 +1534,7 @@ const test_40_2023_7_2 = (sdp, params) => {
   for (let stream of mtParams) {
     if (typeof stream.TM !== 'undefined') {
       if (tmPermitted40.indexOf(stream.TM) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TM' is not set to the required value as per ST 2110-40:2023 Section 7.`));
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TM' is not set to a required value as per ST 2110-40:2023 Section 7.`));
       }
     }
   }
@@ -1547,14 +1550,14 @@ const test_40_2023_7_3 = (sdp, params) => {
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined' && stream.SSN !== 'ST2110-40:2018') {
       if (typeof stream.exactframerate === 'undefined') {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'exactframerate' is not set to the required value as per ST 2110-40:2023 Section 7.`));
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'exactframerate' is not present and is required by  ST 2110-40:2023 Section 7.`));
       } else {
         errors = errors.concat(checkExactframerate(stream));
       }
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-40:2023 Section 7 Test 3 - Exactframerate is as specified.');
+    console.log('Test Passed: ST 2110-40:2023 Section 7 Test 3 - Exactframerate is present');
   }
   return errors;
 };

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -71,10 +71,12 @@ a=rtpmap:112 raw/90000
 a=fmtp:112 sampling=YCbCr-4:2:2; width=1280; height=720; exactframerate=60000/1001; depth=10; TCS=SDR; colorimetry=BT709; PM=2110GPM; SSN=ST2110-20:2017;
 a=ts-refclk:ptp=IEEE1588-2008:39-A7-94-FF-FE-07-CB-D0:37
 a=mediaclk:direct=0
-a=mid:secondary`;
+a=mid:secondary
+`;
 
 // Example SDP data from VSF TR-08:2022 Appendix A
 // See https://videoservicesforum.com/download/technical_recommendations/VSF_TR-08_2022-04-20.pdf
+// NOTE: this example in this revision of TR-08 still has some syntax errors (b= lines are in wrong position, and the sampling and level values do not use the correct '-' character)
 const specExample22 = `v=0
 o=- 101202 53 IN IP4 10.0.81.54
 s=237.0.0.50:22000
@@ -91,15 +93,18 @@ b=AS:116000
 a=ssrc:0 cname:nmos@nmos.tv
 a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
 a=mediaclk:direct=0
-a=mid:PRIMARY m=video 22000 RTP/AVP 98
+a=mid:PRIMARY
+m=video 22000 RTP/AVP 98
 c=IN IP4 237.64.0.50/32
 a=source-filter: incl IN IP4 237.64.0.50 10.0.81.154
 a=rtpmap:98 jxsv/90000
 a=fmtp:98 sampling=YCbCr-4:2:2;width=1280;height=720;packetmode=0;exactframerate=60000/1001;depth=10;TCS=SDR;colorimetry=BT709;SSN=ST2110-22:2019;TP=2110TPN;level=1k-1;sublevel=Sublev3bpp
-b=AS:116000 a=ssrc:0 cname:nmos@nmos.tv
+b=AS:116000
+a=ssrc:0 cname:nmos@nmos.tv
 a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
 a=mediaclk:direct=0
-a=mid:SECONDARY`;
+a=mid:SECONDARY
+`;
 
 // NOTE: all ST 2110 references are for the originally published specifications unless a later revision is indicated
 

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -101,7 +101,7 @@ a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
 a=mediaclk:direct=0 
 a=mid:SECONDARY`;
 
-// ST 2110-10:2017 Section 7.4 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero
+// ST 2110-10 Section 7.4 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero
 // [Also ST 2110-10:2022 Section 8.3]
 const test_10_74_1 = (sdp, params) => {
   let errors = [];
@@ -113,7 +113,7 @@ const test_10_74_1 = (sdp, params) => {
       zeroCheck = zeroCheck.map(z => +(z.trim().split('=')[2]));
       for (let x = 0; x < zeroCheck.length; x++) {
         if (zeroCheck[x] !== 0) {
-          errors.push(new Error(`Stream ${s + 1}: The 'mediaclk' attribute shall have a zero offset when direct-referenced PTP timing is in use, as per ST 2110-10:2017 Section 7.4 and ST 2110-10:2022 Section 8.3.`));
+          errors.push(new Error(`Stream ${s + 1}: The 'mediaclk' attribute shall have a zero offset when direct-referenced PTP timing is in use, as per ST 2110-10 Section 7.4 [also ST 2110-10:2022 Section 8.3].`));
         }
       }
     }
@@ -131,16 +131,16 @@ const test_10_81_1 = (sdp, params) => {
   let streams = sdp.split(/[\r\n]m=/).slice(1);
   for (let s = 0; s < streams.length; s++) {
     if (!mediaclkPattern.test(streams[s])) {
-      errors.push(new Error(`Stream ${s + 1}: Each stream description shall have a media-level 'mediaclk' attribute, as per ST 2110-10:2017 Section 8.1 and ST 2110-10:2022 Section 8.3.`));
+      errors.push(new Error(`Stream ${s + 1}: Each stream description shall have a media-level 'mediaclk' attribute, as per ST 2110-10 Section 8.1 [also ST 2110-10:2022 Section 8.3].`));
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-10:2017 Section 8.1 [also ST 2110-10:2022 Section 8.3] Test 1 - Shall have media-level mediaclk per stream');
+    console.log('Test Passed: ST 2110-10 Section 8.1 [also ST 2110-10:2022 Section 8.3] Test 1 - Shall have media-level mediaclk per stream');
   }
   return errors;
 };
 
-// ST 2110-10:2017 Section 8.1 Test 2 - Should have mediaclk using direct reference
+// ST 2110-10 Section 8.1 Test 2 - Should have mediaclk using direct reference
 // [Also ST 2110-10:2022 Section 8.3 - Shall have mediaclk using direct or sender reference]
 const test_10_81_2 = (sdp, params) => {
   if (!params.should) {
@@ -788,14 +788,14 @@ const test_20_72_4 = (sdp, params) => {
 
 const ssnPermitted20 = ['ST2110-20:2017', 'ST2110-20:2022'];
 
-// ST 2110-20:2017 Section 7.2 Test 5 - Check SSN is the required fixed value
+// ST 2110-20 Section 7.2 Test 5 - Check SSN is the required fixed value
 // [also ST 2110-20:2022 Section 7.2]
 const test_20_72_5 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined') {
       if (ssnPermitted20.indexOf(stream.SSN) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-20:2017 and ST 2110-20:2022 Section 7.2.`));
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-20 [also ST 2110-20:2022 Section 7.2].`));
       } else {
         let detect2022tcs = typeof stream.TCS !== 'undefined' && stream.TCS === 'ST2115LOGS3';
         let detect2022colorimetry = typeof stream.colorimetry !== 'undefined' && stream.colorimetry === 'ALPHA';
@@ -810,7 +810,7 @@ const test_20_72_5 = (sdp, params) => {
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-20:2017 and ST 2110-20:2022 Section 7.2 Test 5 - SSN is the required fixed value \'ST 2110-20:2017\'');
+    console.log('Test Passed: ST 2110-20 Section 7.2 [also ST 2110-20:2022 Section 7.2] Test 5 - SSN is the required fixed value.');
   }
   return errors;
 };
@@ -963,14 +963,14 @@ const colorPermitted2017 = [
 
 const colorPermitted2022 = ['ALPHA'];
 
-// ST 2110-20:2017 Section 7.5
-// ST 2110-20:2022 Section 7.4 Test 1 - Colorimetry is a permitted value.
+// ST 2110-20 Section 7.5 Test 1 - Colorimetry is a permitted value.
+// [also ST 2110-20:2022 Section 7.4]
 const test_20_75_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.colorimetry !== 'undefined') {
       if (colorPermitted2017.indexOf(stream.colorimetry) < 0 && colorPermitted2022.indexOf(stream.colorimetry) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'colorimetry' is not a permitted value, as per ST 2110-20:2017 Section 7.5 and ST 2110-20:2022 Section 7.4.`));
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'colorimetry' is not a permitted value, as per ST 2110-20 Section 7.5 [also ST 2110-20:2022 Section 7.4].`));
       }
     }
   }
@@ -1009,19 +1009,19 @@ const tcsPermitted2017 = [
 
 const tcsPermitted2022 = ['ST2115LOGS3'];
 
-// ST 2110-20:2017 Section 7.6 
-// ST 2110-20:2022 Section 7.5 Test 1 - TCS is a permitted value
+// ST 2110-20 Section 7.6 Test 1 - TCS is a permitted value
+// [also ST 2110-20:2022 Section 7.5]
 const test_20_76_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.TCS !== 'undefined') {
       if (tcsPermitted2017.indexOf(stream.TCS) < 0 && tcsPermitted2022.indexOf(stream.TCS) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TCS' (Transfer Characteristic System) is not a permitted value, as per ST 2110-20:2017 Section 7.6 and ST 2110-20:2012 Section 7.5.`));
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TCS' (Transfer Characteristic System) is not a permitted value, as per ST 2110-20 Section 7.6 [also ST 2110-20:2012 Section 7.5].`));
       }
     }
   }
   if (params.verbose && errors.length == 0) {
-    console.log('Test Passed: ST 2110-20:2017 Section 7.6, ST 2110-20:2022 Section 7.5 Test 1 - TCS is a permitted value');
+    console.log('Test Passed: ST 2110-20 Section 7.6 [also ST 2110-20:2022 Section 7.5] Test 1 - TCS is a permitted value');
   }
   return errors;
 };

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -461,7 +461,7 @@ const test_10_62_1 = (sdp, params) => {
 const tsmodePermitted2022 = ['SAMP', 'NEW', 'PRES'];
 
 // ST 2110-10:2022 Section 8.7 Test 1 - RTP Timestamp Mode and Delay, TSMODE and TSDELAY parameters are an acceptable value.
-const test_10_87_1 = (sdp, params) => {
+const test_10_2022_87_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, { checkDups: true });
   for (let stream of mtParams) {
     let keys = Object.keys(stream);
@@ -1580,8 +1580,8 @@ const section_10_83 = (sdp, params) => {
   return concat(tests.map(t => t(sdp, params)));
 };
 
-const section_10_87 = (sdp, params) => {
-  let tests = [test_10_87_1];
+const section_10_2022_87 = (sdp, params) => {
+  let tests = [test_10_2022_87_1];
   return concat(tests.map(t => t(sdp, params)));
 };
 
@@ -1701,7 +1701,7 @@ const allSections = (sdp, params) => {
     // Load tests based on encoding name
     if (mtParams[0]._encodingName == 'jxsv') {
       sections = [
-        section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_87,
+        section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87,
         section_21_81, section_21_82,
         section_22_60, section_22_72, section_22_73, section_22_74, section_22_2022_72];
       if (params.noCopy) {
@@ -1709,7 +1709,7 @@ const allSections = (sdp, params) => {
       }
     } else if (mtParams[0]._encodingName == 'raw') {
       sections = [
-        section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_87,
+        section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87,
         section_20_71, section_20_72, section_20_73, section_20_74,
         section_20_75, section_20_76, section_21_81, section_21_82];
       if (params.noCopy) {
@@ -1719,16 +1719,16 @@ const allSections = (sdp, params) => {
       sections = [section_40_2023_7];
     } else {
       sections = [
-        section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_87];
+        section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87];
     }
   } else if (mtParams[0]._mediaType == 'audio') {
     sections = [
-      section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_87,
+      section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87,
       section_30_62];
   }
   else {
     sections = [
-      section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_87];
+      section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87];
   }
 
   return concat(sections.map(s => s(sdp, params)));
@@ -1741,7 +1741,7 @@ module.exports = {
   section_10_81,
   section_10_82,
   section_10_83,
-  section_10_87,
+  section_10_2022_87,
   section_20_71,
   section_20_72,
   section_20_73,

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1217,7 +1217,7 @@ const test_30_62_5 = (sdp, params) => {
 
 // ST 2110-21 Section 8.1 Test 1 - When traffic shaping, TP parameter is specified.
 const test_21_81_1 = (sdp, params) => {
-  if (params.shaping === false || params.audioOnly === true) {
+  if (params.shaping === false) {
     if (params.verbose) {
       console.log('Test Skipped: ST 2110-21 Section 8.1 Test 1 - TP parameter is specified. Use --shaping to test.');
     }
@@ -1239,7 +1239,7 @@ const typesPermitted = ['2110TPN', '2110TPNL', '2110TPW'];
 
 // ST 2110-21 Section 8.1 Test 2 - When traffic shaping, TP parameter is an acceptable value
 const test_21_81_2 = (sdp, params) => {
-  if (params.shaping === false || params.audioOnly === true) {
+  if (params.shaping === false) {
     if (params.verbose) {
       console.log('Test Skipped: ST 2110-21 Section 8.1 Test 2 - TP parameter is acceptable value. Use --shaping to test.');
     }
@@ -1277,7 +1277,7 @@ const checkTroff = (stream = {}) => {
 
 // ST 2110-21 Section 8.2 Test 1 - When traffic shaping and TROFF parameter specified, it is an acceptable value
 const test_21_82_1 = (sdp, params) => {
-  if (params.shaping === false || params.audioOnly === true) {
+  if (params.shaping === false) {
     if (params.verbose) {
       console.log('Test Skipped: ST 2110-21 Section 8.2 Test 1 - When TROFF parameter specified, it is an acceptable value. Use --shaping to test.');
     }
@@ -1297,7 +1297,7 @@ const test_21_82_1 = (sdp, params) => {
 
 // ST 2110-21 Section 8.2 Test 2 - When traffic shaping and CMAX parameter specified, it is an acceptable value
 const test_21_82_2 = (sdp, params) => {
-  if (params.shaping === false || params.audioOnly === true) {
+  if (params.shaping === false) {
     if (params.verbose) {
       console.log('Test Skipped: ST 2110-21 Section 8.2 Test 2 - When CMAX parameter specified, it is an acceptable value. Use --shaping to test.');
     }

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1716,7 +1716,8 @@ const allSections = (sdp, params) => {
         sections.push(no_copy_20);
       }
     } else if (mtParams[0]._encodingName == 'smpte291') {
-      sections = [section_40_2023_7];
+      sections = [section_10_62, section_10_74, section_10_81, section_10_82,
+        section_10_83, section_10_2022_87, section_40_2023_7];
     } else {
       sections = [
         section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87];

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -806,10 +806,10 @@ const test_20_72_5 = (sdp, params) => {
         let detect2022tcs = typeof stream.TCS !== 'undefined' && stream.TCS === 'ST2115LOGS3';
         let detect2022colorimetry = typeof stream.colorimetry !== 'undefined' && stream.colorimetry === 'ALPHA';
 
-        if ((detect2022tcs || detect2022colorimetry) && stream.SSN !== 'ST2110-20:2022') {
+        if ((detect2022tcs || detect2022colorimetry) && stream.SSN === 'ST2110-20:2017') {
           errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-20:2022 Section 7.2.`));
         }
-        if (!(detect2022tcs || detect2022colorimetry) && stream.SSN === 'ST2110-20:2022') {
+        if (!(detect2022tcs || detect2022colorimetry) && stream.SSN !== 'ST2110-20:2017') {
           errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-20:2022 Section 7.2.`));
         }
       }

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1756,5 +1756,6 @@ module.exports = {
   section_22_74,
   section_22_2022_72,
   section_21_81,
-  section_21_82
+  section_21_82,
+  section_40_2023_7
 };

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -736,6 +736,15 @@ const test_20_72_2 = (sdp, params) => {
 
 const greatestCommonDivisor = (a, b) => !b ? a : greatestCommonDivisor(b, a % b);
 
+
+/* 
+Function to check ST 2110-20 Section 7.2
+Checks for integer numerator/denominator when required
+Checks if frame rate expressed as a ratio of integers is in lowest common denominator form.
+
+**_exactframerate Signals the frame rate in frames per second. Integer frame rates shall be signaled as a single decimal number (e.g. “25”) whilst non-integer frame rates shall be signaled as a ratio of two integer decimal numbers separated by a “forward-slash”_**
+
+*/
 const checkExactframerate = (stream = {}) => {
   let errors = [];
   let frMatch = stream.exactframerate.match(frameRatePattern);

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -471,7 +471,7 @@ const test_10_2022_87_1 = (sdp, params) => {
       }
     }
     if (keys.indexOf('TSDELAY') >= 0) {
-      if(isNaN(stream.TSDELAY)) {
+      if (isNaN(stream.TSDELAY)) {
         errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TSDELAY' is not set to the required value as per ST 2110-10:2022 Section 8.7.`));
       }
     }
@@ -482,8 +482,8 @@ const test_10_2022_87_1 = (sdp, params) => {
   return errors;
 };
 
-// Function to check that rtpmap is present and has passed in type and clockRate.  
-// An optional specification string can be used to be included in errors 
+// Function to check that rtpmap is present and has passed in type and clockRate.
+// An optional specification string can be used to be included in errors
 // produced as a reference back to a spec
 const checkStreamsRtpMap = (sdp, params, type, clockRate, specification) => {
   let errors = [];
@@ -1385,7 +1385,7 @@ const test_22_73_1 = (sdp, params) => {
 
   for (let s = 0; s < streams.length; s++) {
     // First element from sdp.split is the session level section. Just move ahead the sdp line count
-    if(s == 0) {
+    if (s == 0) {
       let lines = splitLines(streams[s]);
       sdpLineNumb += lines.length;
       continue;
@@ -1462,7 +1462,7 @@ const test_22_74_1 = (sdp, params) => {
         }
         sdpLineNumb++;
       }
-      // If neither exactframerate or framerate attribute present and sessionFramerate not specified- load up error 
+      // If neither exactframerate or framerate attribute present and sessionFramerate not specified, load up error
       if (!framerateAttributePresent && !framerateParameterPresent) {
         errors.push(new Error(`Media Stream ${s}: Framerate must specified as either an attribute or a parameter of video fmtp as per ST 2110-22 Section 7.4.`));
       }
@@ -1528,7 +1528,7 @@ const test_40_2023_7_3 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined' && stream.SSN !== 'ST2110-40:2018') {
-      if(typeof stream.exactframerate === 'undefined') {
+      if (typeof stream.exactframerate === 'undefined') {
         errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'exactframerate' is not set to the required value as per ST 2110-40:2023 Section 7.`));
       } else {
         errors = errors.concat(checkExactframerate(stream));
@@ -1661,7 +1661,7 @@ const section_40_2023_7 = (sdp, params) => {
   let tests = [test_40_2023_7_1, test_40_2023_7_2, test_40_2023_7_3, test_40_2023_7_4];
   return concat(tests.map(t => t(sdp, params)));
 };
-    
+
 const no_copy = (sdp, specSDP) => {
   let lines = splitLines(sdp.trim());
   let exlines = splitLines(specSDP);

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1350,7 +1350,7 @@ const test_22_72_1 = (sdp, params) => {
 const ssnPermitted22 = ['ST2110-22:2019', 'ST2110-22:2022'];
 
 // ST 2110-22:2022 Section 7.2 Test 2 - If present, check SSN is the required fixed value
-const test_22_72_2 = (sdp, params) => {
+const test_22_2022_72_2 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined') {
@@ -1549,7 +1549,7 @@ const section_22_60 = (sdp, params) => {
 };
 
 const section_22_72 = (sdp, params) => {
-  let tests = [test_22_72_1, test_22_72_2];
+  let tests = [test_22_72_1, test_22_2022_72_2];
   return concat(tests.map(t => t(sdp, params)));
 };
 

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -786,7 +786,7 @@ const test_20_72_4 = (sdp, params) => {
   return errors;
 };
 
-const ssnPermitted = ['ST2110-20:2017', 'ST2110-20:2022'];
+const ssnPermitted20 = ['ST2110-20:2017', 'ST2110-20:2022'];
 
 // ST 2110-20:2017 Section 7.2
 // ST 2110-20:2022 Section 7.2 Test 5 - Check SSN is the required fixed value
@@ -794,17 +794,17 @@ const test_20_72_5 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined') {
-      if (ssnPermitted.indexOf(stream.SSN) < 0) {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value 'ST2110-20:2017' or 'ST2110-20:2022', as per ST 2110-20:2017 and ST 2110-20:2022 Section 7.2.`));
+      if (ssnPermitted20.indexOf(stream.SSN) < 0) {
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-20:2017 and ST 2110-20:2022 Section 7.2.`));
       } else {
         let detect2022tcs = typeof stream.TCS !== 'undefined' && stream.TCS === 'ST2115LOGS3';
         let detect2022colorimetry = typeof stream.colorimetry !== 'undefined' && stream.colorimetry === 'ALPHA';
 
         if ((detect2022tcs || detect2022colorimetry) && stream.SSN !== 'ST2110-20:2022') {
-          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value 'ST2110-20:2022', as per ST 2110-20:2022 Section 7.2.`));
+          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-20:2022 Section 7.2.`));
         }
         if (!(detect2022tcs || detect2022colorimetry) && stream.SSN === 'ST2110-20:2022') {
-          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value 'ST2110-20:2017', as per ST 2110-20:2022 Section 7.2.`));
+          errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-20:2022 Section 7.2.`));
         }
       }
     }
@@ -1347,6 +1347,24 @@ const test_22_72_1 = (sdp, params) => {
   return errors;
 };
 
+const ssnPermitted22 = ['ST2110-22:2019', 'ST2110-22:2022'];
+
+// ST 2110-22:2022 Section 7.2 Test 2 - If present, check SSN is the required fixed value
+const test_22_72_2 = (sdp, params) => {
+  let [mtParams, errors] = extractMTParams(sdp, params);
+  for (let stream of mtParams) {
+    if (typeof stream.SSN !== 'undefined') {
+      if (ssnPermitted22.indexOf(stream.SSN) < 0) {
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'SSN' is not set to the required value as per ST 2110-22:2022 Section 7.2.`));
+      }
+    }
+  }
+  if (params.verbose && errors.length == 0) {
+    console.log('Test Passed: ST 2110-22:2022 Section 7.2 Test 5 - SSN is the required fixed value \'ST 2110-20:2017\'');
+  }
+  return errors;
+};
+
 // ST 2110-22 Section 7.3 Test 1 - Check for mandatory bandwidth-field in correct format
 const test_22_73_1 = (sdp, params) => {
   let streams = sdp.split(/[\r\n]m=/);
@@ -1531,7 +1549,7 @@ const section_22_60 = (sdp, params) => {
 };
 
 const section_22_72 = (sdp, params) => {
-  let tests = [test_22_72_1];
+  let tests = [test_22_72_1, test_22_72_2];
   return concat(tests.map(t => t(sdp, params)));
 };
 

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -963,11 +963,11 @@ const test_20_74_2 = (sdp, params) => {
   return errors;
 };
 
-const colorPermitted2017 = [
+const colorPermitted20_2017 = [
   'BT601', 'BT709', 'BT2020', 'BT2100', 'ST2065-1',
   'ST2065-3', 'UNSPECIFIED', 'XYZ'];
 
-const colorPermitted2022 = ['ALPHA'];
+const colorPermitted20_2022 = ['ALPHA'];
 
 // ST 2110-20 Section 7.5 Test 1 - Colorimetry is a permitted value.
 // [also ST 2110-20:2022 Section 7.4]
@@ -975,7 +975,7 @@ const test_20_75_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.colorimetry !== 'undefined') {
-      if (colorPermitted2017.indexOf(stream.colorimetry) < 0 && colorPermitted2022.indexOf(stream.colorimetry) < 0) {
+      if (colorPermitted20_2017.indexOf(stream.colorimetry) < 0 && colorPermitted20_2022.indexOf(stream.colorimetry) < 0) {
         errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'colorimetry' is not a permitted value, as per ST 2110-20 Section 7.5 [also ST 2110-20:2022 Section 7.4].`));
       }
     }
@@ -1008,12 +1008,12 @@ const test_20_75_2 = (sdp, params) => {
   return errors;
 };
 
-const tcsPermitted2017 = [
+const tcsPermitted20_2017 = [
   'SDR', 'PQ', 'HLG', 'LINEAR', 'BT2100LINPQ', 'BT2100LINHLG', 'ST2065-1',
   'ST428-1', 'DENSITY', 'UNSPECIFIED'
 ];
 
-const tcsPermitted2022 = ['ST2115LOGS3'];
+const tcsPermitted20_2022 = ['ST2115LOGS3'];
 
 // ST 2110-20 Section 7.6 Test 1 - TCS is a permitted value
 // [also ST 2110-20:2022 Section 7.5]
@@ -1021,7 +1021,7 @@ const test_20_76_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.TCS !== 'undefined') {
-      if (tcsPermitted2017.indexOf(stream.TCS) < 0 && tcsPermitted2022.indexOf(stream.TCS) < 0) {
+      if (tcsPermitted20_2017.indexOf(stream.TCS) < 0 && tcsPermitted20_2022.indexOf(stream.TCS) < 0) {
         errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'TCS' (Transfer Characteristic System) is not a permitted value, as per ST 2110-20 Section 7.6 [also ST 2110-20:2012 Section 7.5].`));
       }
     }

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -101,6 +101,8 @@ a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
 a=mediaclk:direct=0
 a=mid:SECONDARY`;
 
+// NOTE: all ST 2110 references are for the originally published specifications unless otherwise indicated
+
 // ST 2110-10 Section 7.4 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero
 // [Also ST 2110-10:2022 Section 8.3]
 const test_10_74_1 = (sdp, params) => {

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1716,7 +1716,8 @@ const allSections = (sdp, params) => {
         sections.push(no_copy_20);
       }
     } else if (mtParams[0]._encodingName == 'smpte291') {
-      sections = [section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87,
+      sections = [
+        section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_2022_87,
         section_40_2023_7];
     } else {
       sections = [

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -75,30 +75,30 @@ a=mid:secondary`;
 
 // Example SDP data from VSF TR-08:2022 Appendix A
 // See https://videoservicesforum.com/download/technical_recommendations/VSF_TR-08_2022-04-20.pdf
-const specExample22 = `v=0 
-o=- 101202 53 IN IP4 10.0.81.54 
-s=237.0.0.50:22000 
-i=Nmos Testing 237.0.0.50:22000 
-t=0 0 
-a=recvonly 
-a=group:DUP PRIMARY SECONDARY 
-m=video 22000 RTP/AVP 98 
-c=IN IP4 237.0.0.50/32 
-a=source-filter: incl IN IP4 237.0.0.50 10.0.81.54 
-a=rtpmap:98 jxsv/90000 
-a=fmtp:98 sampling=YCbCr-4:2:2;width=1280;height=720;packetmode=0;exactframerate=60000/1001;depth=10;TCS=SDR;colorimetry=BT709;SSN=ST2110-22:2019;TP=2110TPN;level=1k-1;sublevel=Sublev3bpp 
-b=AS:116000 
-a=ssrc:0 cname:nmos@nmos.tv 
-a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127 
-a=mediaclk:direct=0 
-a=mid:PRIMARY m=video 22000 RTP/AVP 98 
-c=IN IP4 237.64.0.50/32 
-a=source-filter: incl IN IP4 237.64.0.50 10.0.81.154 
-a=rtpmap:98 jxsv/90000 
-a=fmtp:98 sampling=YCbCr-4:2:2;width=1280;height=720;packetmode=0;exactframerate=60000/1001;depth=10;TCS=SDR;colorimetry=BT709;SSN=ST2110-22:2019;TP=2110TPN;level=1k-1;sublevel=Sublev3bpp 
-b=AS:116000 a=ssrc:0 cname:nmos@nmos.tv 
-a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127 
-a=mediaclk:direct=0 
+const specExample22 = `v=0
+o=- 101202 53 IN IP4 10.0.81.54
+s=237.0.0.50:22000
+i=Nmos Testing 237.0.0.50:22000
+t=0 0
+a=recvonly
+a=group:DUP PRIMARY SECONDARY
+m=video 22000 RTP/AVP 98
+c=IN IP4 237.0.0.50/32
+a=source-filter: incl IN IP4 237.0.0.50 10.0.81.54
+a=rtpmap:98 jxsv/90000
+a=fmtp:98 sampling=YCbCr-4:2:2;width=1280;height=720;packetmode=0;exactframerate=60000/1001;depth=10;TCS=SDR;colorimetry=BT709;SSN=ST2110-22:2019;TP=2110TPN;level=1k-1;sublevel=Sublev3bpp
+b=AS:116000
+a=ssrc:0 cname:nmos@nmos.tv
+a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
+a=mediaclk:direct=0
+a=mid:PRIMARY m=video 22000 RTP/AVP 98
+c=IN IP4 237.64.0.50/32
+a=source-filter: incl IN IP4 237.64.0.50 10.0.81.154
+a=rtpmap:98 jxsv/90000
+a=fmtp:98 sampling=YCbCr-4:2:2;width=1280;height=720;packetmode=0;exactframerate=60000/1001;depth=10;TCS=SDR;colorimetry=BT709;SSN=ST2110-22:2019;TP=2110TPN;level=1k-1;sublevel=Sublev3bpp
+b=AS:116000 a=ssrc:0 cname:nmos@nmos.tv
+a=ts-refclk:ptp=IEEE1588-2008:08-00-11-FF-FE-22-91-3C:127
+a=mediaclk:direct=0
 a=mid:SECONDARY`;
 
 // ST 2110-10 Section 7.4 Test 1 - Where mediaclk:direct is used with PTP, offset value is zero

--- a/checkST2110.js
+++ b/checkST2110.js
@@ -1349,8 +1349,8 @@ const test_22_72_1 = (sdp, params) => {
 
 const ssnPermitted22 = ['ST2110-22:2019', 'ST2110-22:2022'];
 
-// ST 2110-22:2022 Section 7.2 Test 2 - If present, check SSN is the required fixed value
-const test_22_2022_72_2 = (sdp, params) => {
+// ST 2110-22:2022 Section 7.2 Test 1 - If present, check SSN is the required fixed value
+const test_22_2022_72_1 = (sdp, params) => {
   let [mtParams, errors] = extractMTParams(sdp, params);
   for (let stream of mtParams) {
     if (typeof stream.SSN !== 'undefined') {
@@ -1549,7 +1549,7 @@ const section_22_60 = (sdp, params) => {
 };
 
 const section_22_72 = (sdp, params) => {
-  let tests = [test_22_72_1, test_22_2022_72_2];
+  let tests = [test_22_72_1];
   return concat(tests.map(t => t(sdp, params)));
 };
 
@@ -1560,6 +1560,11 @@ const section_22_73 = (sdp, params) => {
 
 const section_22_74 = (sdp, params) => {
   let tests = [test_22_74_1];
+  return concat(tests.map(t => t(sdp, params)));
+};
+
+const section_22_2022_72 = (sdp, params) => {
+  let tests = [test_22_2022_72_1];
   return concat(tests.map(t => t(sdp, params)));
 };
 
@@ -1604,7 +1609,7 @@ const allSections = (sdp, params) => {
       sections = [
         section_10_62, section_10_74, section_10_81, section_10_82, section_10_83, section_10_87,
         section_21_81, section_21_82,
-        section_22_60, section_22_72, section_22_73, section_22_74];
+          section_22_60, section_22_72, section_22_73, section_22_74, section_22_2022_72];
       if (params.noCopy) {
         sections.push(no_copy_22);
       }
@@ -1652,6 +1657,7 @@ module.exports = {
   section_22_72,
   section_22_73,
   section_22_74,
+  section_22_2022_72,
   section_21_81,
   section_21_82
 };


### PR DESCRIPTION
Updated ST 2110 validation according to latest ST 2110 specifications:

- ST 2110-10: Check `mediaclk` is using `direct` or `sender` reference.
- ST 2110-10: Check `TSMODE` and `TSDELAY` parameters.
- ST 2110-20: Update permitted `SSN` values.
- ST 2110-20: Update `colorimetry` to include `ALPHA`.
- ST 2110-20: Update `TCS` to include `ST2115LOGS3`.
- ST 2110-22: Check permitted `SSN` value.

-21:2022 -31:2022, -40:2023 and -43:2021 checked but no changes seemed appropriate (please correct me on this if I am mistaken).

This PR resolves #24.



